### PR TITLE
fix: Set filteredColumn to -1 by default

### DIFF
--- a/table.go
+++ b/table.go
@@ -166,7 +166,7 @@ func NewTable(width, height int, columnHeaders []string) *Table {
 		orderedColumnIndex: -1,
 		orderedColumnPhase: TableSortingDescending,
 
-		filteredColumn: 0,
+		filteredColumn: -1,
 		filterString:   "",
 
 		height: height,


### PR DESCRIPTION
This fixes a rendering bug with the current `NewTable` function which sets the filtered column to `0` rather than `-1` by default. This means that the footer always shows "filter by" even when the user has not started filtering.

You can use the `examples` folder projects to recreate and see the fix.